### PR TITLE
Fix bounds init values to work west of greenwich.

### DIFF
--- a/src/net/morbz/osmonaut/geometry/Bounds.java
+++ b/src/net/morbz/osmonaut/geometry/Bounds.java
@@ -32,8 +32,8 @@ import net.morbz.osmonaut.util.StringUtil;
  * @author MorbZ
  */
 public class Bounds {
-	private double minLat = Double.MAX_VALUE, maxLat = Double.MIN_VALUE;
-	private double minLon = Double.MAX_VALUE, maxLon = Double.MIN_VALUE;
+	private double minLat = Double.MAX_VALUE, maxLat = -Double.MAX_VALUE;
+	private double minLon = Double.MAX_VALUE, maxLon = -Double.MAX_VALUE;
 	private boolean initialized = false;
 	
 	/**


### PR DESCRIPTION
`Double.MIN_VALUE` is the smallest **positive nonzero value** of type double, that is 2^-1074. This make the bounds computation to break west of greenwhich (where I live...). It should be replaced by `-Double.MAX_VALUE`.